### PR TITLE
Adding in new ops file to limit max tasks to 200 from default 2000 to save disk space

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -49,6 +49,7 @@ jobs:
       - bosh-config/operations/add-new-saml-key.yml
       - bosh-config/operations/remove-old-blobstore-ca.yml
       - bosh-config/operations/add-cloud-gov-root-certificate.yml
+      - bosh-config/operations/max-files.yml
       vars_files:
       - bosh-config/variables/development.yml
       - terraform-secrets/terraform.yml
@@ -627,7 +628,7 @@ resources:
 - name: cron-release
   type: bosh-io-release
   source:
-    repository: cloudfoundry-community/cron-boshrelease  
+    repository: cloudfoundry-community/cron-boshrelease
 
 - name: ntp-release
   type: bosh-io-release
@@ -825,4 +826,3 @@ resource_types:
   type: docker-image
   source:
     repository: governmentpaas/semver-resource
-

--- a/operations/max-tasks.yml
+++ b/operations/max-tasks.yml
@@ -1,0 +1,3 @@
+- type: replace
+  path: /instance_groups/name=bosh/properties/director/max_tasks?
+  value: 200


### PR DESCRIPTION
## Changes proposed in this pull request:
- Update `director.max_tasks` value from default of 2000 to 200 (10%)
- Update pipeline to use new ops file

## security considerations
None

Signed-off-by: Chris McGowan (christopher.r.mcgowan@gsa.gov)