### PR TITLE
adding to cloud config for 250 diego cell disk size

### DIFF
--- a/cloud-config/cf.yml
+++ b/cloud-config/cf.yml
@@ -85,6 +85,13 @@
 - type: replace
   path: /vm_extensions/-
   value:
+    name: 250GB_ephemeral_disk
+    cloud_properties:
+      ephemeral_disk:
+        size: 256000
+- type: replace
+  path: /vm_extensions/-
+  value:
     name: 500GB_ephemeral_disk
     cloud_properties:
       ephemeral_disk:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adding in a 250 gb disk size for diego-cells
- Prelim for ticket: https://github.com/cloud-gov/cg-deploy-cf/issues/492

## security considerations
N/A
