### PR TITLE
Increase disk size for BOSH

### DIFF
--- a/cloud-config/tooling.yml
+++ b/cloud-config/tooling.yml
@@ -299,7 +299,7 @@
   path: /disk_types/-
   value:
     name: bosh
-    disk_size: 80_000
+    disk_size: 92_000
 - type: replace
   path: /disk_types/-
   value:


### PR DESCRIPTION
We are starting to receive alerts that the disk space is filling up in our BOSH instances.  This changeset increases the available disk space by 15%.

## Changes proposed in this pull request:
- Increase disk size by 15% to 92,000 in the tooling BOSH configuration so it flows to the rest of the BOSH instances

## security considerations
None; this is a configuration adjustment of our open source infrastructure.
