### PR TITLE
Doubling logsearch data disk from 3.5 to 7 TB

### DIFF
--- a/cloud-config/main.yml
+++ b/cloud-config/main.yml
@@ -90,7 +90,7 @@
   path: /disk_types/-
   value:
     name: logsearch_es_data
-    disk_size: 3_500_000
+    disk_size: 7_000_000
 - type: replace
   path: /disk_types/-
   value:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Increase the base logsearch data persistent disk from 3.5 to 7 TB

## security considerations
n/a
