### PR TITLE
Remove logsearch and logsearch-for-cloudfoundry releases

### DIFF
--- a/releases/releases.yml
+++ b/releases/releases.yml
@@ -33,12 +33,6 @@ releases:
 - name: kubernetes
   uri: https://github.com/cloud-gov/kubernetes-release
   branch: master
-- name: logsearch
-  uri: https://github.com/cloud-gov/logsearch-boshrelease
-  branch: develop
-- name: logsearch-for-cloudfoundry
-  uri: https://github.com/cloud-gov/logsearch-for-cloudfoundry
-  branch: develop
 - name: elastalert
   uri: https://github.com/cloud-gov/elastalert-boshrelease
   branch: master


### PR DESCRIPTION
## Changes proposed in this pull request:
- Remove logsearch and logsearch-for-cloudfoundry releases to move them to https://github.com/cloud-gov/cg-deploy-logsearch in order to support adding testing tasks to deployment

## security considerations
None
