### PR TITLE
add credhub security group to concourse network

### DIFF
--- a/cloud-config/tooling.yml
+++ b/cloud-config/tooling.yml
@@ -58,6 +58,7 @@
           security_groups:
             - ((terraform_outputs.bosh_security_group))
             - ((terraform_outputs.staging_concourse_security_group))
+            - ((terraform_outputs.staging_credhub_security_group))
 - type: replace
   path: /networks/-
   value:
@@ -75,6 +76,7 @@
           security_groups:
             - ((terraform_outputs.bosh_security_group))
             - ((terraform_outputs.production_concourse_security_group))
+            - ((terraform_outputs.production_credhub_security_group))
 - type: replace
   path: /networks/-
   value:


### PR DESCRIPTION
## Changes proposed in this pull request:

Adds the credhub security group to the concourse network.

## security considerations

This opens the credhub ports to ingress traffic.
