### PR TITLE
fixing old awslogs path

### DIFF
--- a/operations/cron.yml
+++ b/operations/cron.yml
@@ -42,8 +42,8 @@
               # apps from other packages on this host we need
               PSQL=/var/vcap/packages/postgres-9.4/bin/psql
 
-              AWSCLI=/var/vcap/packages/awslogs-xenial/venv/bin/aws
-              export LD_LIBRARY_PATH=/var/vcap/packages/awslogs-xenial/venv/lib
+              AWSCLI=/var/vcap/packages/awslogs-bionic/venv/bin/aws
+              export LD_LIBRARY_PATH=/var/vcap/packages/awslogs-bionic/venv/lib
 
               # Hack: look up push gateway address in database if gateway is managed by the current director
               if [ -n "${GATEWAY_DEPLOYMENT}" ]; then


### PR DESCRIPTION
## Changes proposed in this pull request:
- Update path for cron ops file to use new aws-logs bionic release

## security considerations
- Proper check of bosh instances inside the VPCs once director moves to bionic
