### PR TITLE
Adding new disk type for doomsday in tooling

### DIFF
--- a/cloud-config/tooling.yml
+++ b/cloud-config/tooling.yml
@@ -320,6 +320,11 @@
 - type: replace
   path: /disk_types/-
   value:
+    name: 5GB
+    disk_size: 5120
+- type: replace
+  path: /disk_types/-
+  value:
     name: nessus-manager
     disk_size: 200_000
 - type: replace


### PR DESCRIPTION
## Changes proposed in this pull request:
- Create 5 GB disk type to support moving doomsday persistent storage to it's own disk

## security considerations
N/A