### PR TITLE
cleanup awslogs-xenial release

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -108,8 +108,6 @@ jobs:
       trigger: true
     - get: cg-s3-fisma-release
       trigger: true
-    - get: cg-s3-awslogs-xenial-release
-      trigger: true
     - get: cg-s3-awslogs-bionic-release
       trigger: true
     - get: cg-s3-nessus-agent-release
@@ -138,7 +136,6 @@ jobs:
       inputs:
       - {name: certificate}
       - {name: cg-s3-fisma-release, path: releases/fisma}
-      - {name: cg-s3-awslogs-xenial-release, path: releases/awslogs-xenial}
       - {name: cg-s3-awslogs-bionic-release, path: releases/awslogs-bionic}
       - {name: cg-s3-nessus-agent-release, path: releases/nessus-agent}
       - {name: cg-s3-clamav-release, path: releases/clamav}
@@ -275,10 +272,6 @@ jobs:
       trigger: true
       passed:
       - common-releases-master
-    - get: cg-s3-awslogs-xenial-release
-      trigger: true
-      passed:
-      - common-releases-master
     - get: cg-s3-awslogs-bionic-release
       trigger: true
       passed:
@@ -321,7 +314,6 @@ jobs:
       inputs:
       - {name: certificate}
       - {name: cg-s3-fisma-release, path: releases/fisma}
-      - {name: cg-s3-awslogs-xenial-release, path: releases/awslogs-xenial}
       - {name: cg-s3-awslogs-bionic-release, path: releases/awslogs-bionic}
       - {name: cg-s3-nessus-agent-release, path: releases/nessus-agent}
       - {name: cg-s3-clamav-release, path: releases/clamav}
@@ -418,10 +410,6 @@ jobs:
     - get: terraform-yaml
       resource: terraform-yaml-development
     - get: cg-s3-fisma-release
-      trigger: true
-      passed:
-      - common-releases-tooling
-    - get: cg-s3-awslogs-xenial-release
       trigger: true
       passed:
       - common-releases-tooling
@@ -553,10 +541,6 @@ jobs:
       trigger: true
       passed:
       - common-releases-development
-    - get: cg-s3-awslogs-xenial-release
-      trigger: true
-      passed:
-      - common-releases-development
     - get: cg-s3-awslogs-bionic-release
       trigger: true
       passed:
@@ -677,10 +661,6 @@ jobs:
     - get: terraform-yaml
       resource: terraform-yaml-production
     - get: cg-s3-fisma-release
-      trigger: true
-      passed:
-      - common-releases-staging
-    - get: cg-s3-awslogs-xenial-release
       trigger: true
       passed:
       - common-releases-staging
@@ -839,12 +819,6 @@ resources:
   type: s3-iam
   source:
     regexp: fisma-(.*).tgz
-    <<: *s3-release-params
-
-- name: cg-s3-awslogs-xenial-release
-  type: s3-iam
-  source:
-    regexp: awslogs-xenial-(.*).tgz
     <<: *s3-release-params
 
 - name: cg-s3-awslogs-bionic-release

--- a/ci/update-runtime-config.yml
+++ b/ci/update-runtime-config.yml
@@ -12,7 +12,6 @@ inputs:
 - {name: terraform-yaml}
 - {name: cg-s3-fisma-release, path: releases/fisma}
 - {name: aide-release, path: releases/aide}
-- {name: cg-s3-awslogs-xenial-release, path: releases/awslogs-xenial}
 - {name: cg-s3-awslogs-bionic-release, path: releases/awslogs-bionic}
 - {name: cg-s3-nessus-agent-release, path: releases/nessus-agent}
 - {name: cg-s3-clamav-release, path: releases/clamav}

--- a/releases/releases.yml
+++ b/releases/releases.yml
@@ -9,9 +9,6 @@ releases:
 - name: nessus-agent
   uri: https://github.com/cloud-gov/cg-nessus-agent-boshrelease
   branch: master
-- name: awslogs-xenial
-  uri: https://github.com/cloud-gov/cg-awslogs-boshrelease
-  branch: master
 - name: awslogs-bionic
   uri: https://github.com/cloud-gov/cg-awslogs-boshrelease
   branch: bionic

--- a/runtime-config/runtime.yml
+++ b/runtime-config/runtime.yml
@@ -3,28 +3,24 @@ releases:
 - {name: aide, version: ((release_aide))}
 - {name: clamav, version: ((release_clamav))}
 - {name: snort, version: ((release_snort))}
-- {name: awslogs-xenial, version: ((release_awslogs_xenial))}
 - {name: awslogs-bionic, version: ((release_awslogs_bionic))}
 - {name: nessus-agent, version: ((release_nessus_agent))}
 - {name: node-exporter, version: ((release_node_exporter))}
 - {name: syslog, version: ((release_syslog))}
 
 addons:
-- include:
-    stemcell:
-    - os: ubuntu-xenial
+- name: hardening
   jobs:
-  - name: awslogs-xenial
-    release: awslogs-xenial
-    properties:
-      awslogs-xenial:
-        region: us-gov-west-1
-  name: awslogs-xenial
-- include:
-    stemcell:
-    - os: ubuntu-bionic
-  jobs:
+  - name: harden
+    release: fisma
+  - name: aide
+    release: aide
+  - name: clamav
+    release: clamav
+  - name: snort
+    release: snort
   - name: awslogs-bionic
+    release: awslogs-bionic
     properties:
       awslogs-bionic:
         region: us-gov-west-1
@@ -53,18 +49,6 @@ addons:
           log_stream_name: "{{instance_id}}"
           initial_position: start_of_file
           datetime_format: "%Y-%m-%dT%H:%M:%S"
-    release: awslogs-bionic
-  name: awslogs-bionic
-- name: hardening
-  jobs:
-  - name: harden
-    release: fisma
-  - name: aide
-    release: aide
-  - name: clamav
-    release: clamav
-  - name: snort
-    release: snort
   - name: nessus-agent
     release: nessus-agent
     properties:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Remove logic in runtime config template to select correct awslogs release since we no longer run xenial stemcells
- Remove awslog-xenial release build pipeline
- Remove awslog-xenial release from runtime and bosh releases


## security considerations
n/a
