### PR TITLE
temp add ops entry to migrate PG to PG10 first

### DIFF
--- a/operations/masterbosh-ntp.yml
+++ b/operations/masterbosh-ntp.yml
@@ -20,3 +20,11 @@
     - server time-b-wwv.nist.gov
     - server time-c-wwv.nist.gov
     - server time-d-wwv.nist.gov
+
+# Temp add to validate master bosh is using postgres-10
+
+- type: replace
+  path: /instance_groups/name=bosh/jobs/name=postgres?
+  value:
+    name: postgres-10
+    release: bosh


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add temp ops entry to move PG job default to PG-10 to migrate DB schema to allow newer versions of PG later

## security considerations
Staying current to allow us to follow bosh-deployment and keep patched
