### PR TITLE
adding ops entry to remove default pg job

### DIFF
--- a/operations/external-db.yml
+++ b/operations/external-db.yml
@@ -5,6 +5,9 @@
   path: /instance_groups/name=bosh/jobs/name=postgres-10?
 
 - type: remove
+  path: /instance_groups/name=bosh/jobs/name=postgres?
+
+- type: remove
   path: /instance_groups/name=bosh/properties/postgres
 
 - type: replace


### PR DESCRIPTION
## Changes proposed in this pull request:
- Modify internal external db ops file to now remove default PG job

## security considerations
Allows CG to continue to use bosh deployment to keep BOSH current
