### PR TITLE
chore: Bump cf ephemeral disk config to 300GB

### DIFF
--- a/cloud-config/cf.yml
+++ b/cloud-config/cf.yml
@@ -85,10 +85,10 @@
 - type: replace
   path: /vm_extensions/-
   value:
-    name: 250GB_ephemeral_disk
+    name: 300GB_ephemeral_disk
     cloud_properties:
       ephemeral_disk:
-        size: 256000
+        size: 307200
 - type: replace
   path: /vm_extensions/-
   value:


### PR DESCRIPTION
Updates to support https://github.com/cloud-gov/product/issues/2339

## Changes proposed in this pull request:
- Bumps cf ephemeral disk to 300GB from 250GB

## security considerations
None
