### PR TITLE
Updating runtime to exclude jammy for now

### DIFF
--- a/empty-vm.yml
+++ b/empty-vm.yml
@@ -1,0 +1,36 @@
+instance_groups:
+- azs:
+  - z1
+  instances: 1
+  jobs:
+  - name: clamav
+    properties:
+      clamav:
+        alert_on_stale_defs: ((/clamav_alert_on_stale_defs))
+        cron:
+          schedule: ((/clamav_cron_schedule))
+        dbMirror1: ((/clamav_mirror))
+        exclude_directories: ((/clamav_exclude_directories))
+        include_directories: ((/clamav_include_directories))
+        on_access_enabled: ((/clamav_onaccess_enabled))
+        schedule_enabled: ((/clamav_schedule_enabled))
+    release: clamav
+  name: empty-vm-bionic
+  networks:
+  - name: default
+  persistent_disk: 10240
+  stemcell: default
+  vm_type: t3.medium
+name: empty-jammy-test
+releases:
+- name: clamav
+  version: 37
+stemcells:
+- alias: default
+  os: ubuntu-jammy
+  version: latest
+update:
+  canaries: 2
+  canary_watch_time: 5000-60000
+  max_in_flight: 1
+  update_watch_time: 5000-60000

--- a/runtime-config/runtime.yml
+++ b/runtime-config/runtime.yml
@@ -9,7 +9,27 @@ releases:
 - {name: syslog, version: ((release_syslog))}
 
 addons:
-- name: hardening
+- include:
+    stemcell:
+    - os: ubuntu-jammy
+  name: hardening-jammy
+  jobs:
+  - name: clamav
+    release: clamav
+    properties:
+      clamav:
+        dbMirror1: ((/clamav_mirror))
+        alert_on_stale_defs: ((/clamav_alert_on_stale_defs))
+        schedule_enabled: ((/clamav_schedule_enabled))
+        on_access_enabled: ((/clamav_onaccess_enabled))
+        cron:
+          schedule: ((/clamav_cron_schedule))
+        include_directories: ((/clamav_include_directories)) 
+        exclude_directories: ((/clamav_exclude_directories))
+- include:
+    stemcell:
+    - os: ubuntu-bionic
+  name: hardening
   jobs:
   - name: harden
     release: fisma


### PR DESCRIPTION
## Changes proposed in this pull request:
- Moved harden to include bionic only
- Added harden for jammy
- Add base vm deployment

## security considerations
None.