### PR TITLE
add aide release/job to jammy runtime config

### DIFF
--- a/runtime-config/runtime.yml
+++ b/runtime-config/runtime.yml
@@ -24,7 +24,7 @@ addons:
         on_access_enabled: ((/clamav_onaccess_enabled))
         cron:
           schedule: ((/clamav_cron_schedule))
-        include_directories: ((/clamav_include_directories)) 
+        include_directories: ((/clamav_include_directories))
         exclude_directories: ((/clamav_exclude_directories))
   - name: syslog_forwarder
     properties:
@@ -32,6 +32,8 @@ addons:
         address: ((terraform_outputs.platform_syslog_elb_dns_name))
         port: 5514
     release: syslog
+  - name: aide
+    release: aide
 - include:
     stemcell:
     - os: ubuntu-bionic
@@ -51,7 +53,7 @@ addons:
         on_access_enabled: ((/clamav_onaccess_enabled))
         cron:
           schedule: ((/clamav_cron_schedule))
-        include_directories: ((/clamav_include_directories)) 
+        include_directories: ((/clamav_include_directories))
         exclude_directories: ((/clamav_exclude_directories))
   - name: snort
     release: snort


### PR DESCRIPTION
Closes https://github.com/cloud-gov/product/issues/2398

## Changes proposed in this pull request:

After testing/verifying that AIDE runs properly on a VM built on Ubuntu Jammy, we are adding AIDE to the list of jobs deployed on all VMs in the runtime config for Ubuntu Jammy

## security considerations

None
