### PR TITLE
add FISMA release to jammy runtime

### DIFF
--- a/runtime-config/runtime.yml
+++ b/runtime-config/runtime.yml
@@ -34,6 +34,8 @@ addons:
     release: syslog
   - name: aide
     release: aide
+  - name: harden
+    release: fisma
 - include:
     stemcell:
     - os: ubuntu-bionic


### PR DESCRIPTION
[After testing and confirmed that the cg-harden-boshrelease compiles and deploys successfully on the Ubuntu Jammy runtime](https://github.com/cloud-gov/product/issues/2404), we are adding it to the runtime config so that any VM deployed on the Ubuntu Jammy stemcell will include that release

Closes https://github.com/cloud-gov/product/issues/2404

## security considerations

None
