### PR TITLE
Update releases.yml

### DIFF
--- a/releases/releases.yml
+++ b/releases/releases.yml
@@ -12,6 +12,9 @@ releases:
 - name: awslogs-bionic
   uri: https://github.com/cloud-gov/cg-awslogs-boshrelease
   branch: bionic
+- name: awslogs-jammy
+  uri: https://github.com/cloud-gov/cg-awslogs-boshrelease
+  branch: jammy
 - name: clamav
   uri: https://github.com/cloud-gov/cg-clamav-boshrelease
   branch: master


### PR DESCRIPTION
Related to https://github.com/cloud-gov/product/issues/2397

## Changes proposed in this pull request:

- Add awslogs-jammy to be automatically built by releases pipeline

There is a script which reads the `releases.yml` file and builds a pipeline definition to create and publish BOSH releases from the given repos: https://github.com/cloud-gov/cg-deploy-bosh/blob/main/releases/generate.sh

## security considerations

None, just adding a BOSH release to be built by our pipeline
