### PR TITLE
Add awslogs jammy to runtime config

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -121,6 +121,8 @@ jobs:
       trigger: true
     - get: cg-s3-awslogs-bionic-release
       trigger: true
+    - get: cg-s3-awslogs-jammy-release
+      trigger: true
     - get: cg-s3-nessus-agent-release
       trigger: true
     - get: cg-s3-clamav-release
@@ -148,6 +150,7 @@ jobs:
       - {name: certificate}
       - {name: cg-s3-fisma-release, path: releases/fisma}
       - {name: cg-s3-awslogs-bionic-release, path: releases/awslogs-bionic}
+      - {name: cg-s3-awslogs-jammy-release, path: releases/awslogs-jammy}
       - {name: cg-s3-nessus-agent-release, path: releases/nessus-agent}
       - {name: cg-s3-clamav-release, path: releases/clamav}
       - {name: cg-s3-snort-release, path: releases/snort}
@@ -287,6 +290,10 @@ jobs:
       trigger: true
       passed:
       - common-releases-master
+    - get: cg-s3-awslogs-jammy-release
+      trigger: true
+      passed:
+      - common-releases-master
     - get: cg-s3-nessus-agent-release
       trigger: true
       passed:
@@ -326,6 +333,7 @@ jobs:
       - {name: certificate}
       - {name: cg-s3-fisma-release, path: releases/fisma}
       - {name: cg-s3-awslogs-bionic-release, path: releases/awslogs-bionic}
+      - {name: cg-s3-awslogs-jammy-release, path: releases/awslogs-jammy}
       - {name: cg-s3-nessus-agent-release, path: releases/nessus-agent}
       - {name: cg-s3-clamav-release, path: releases/clamav}
       - {name: cg-s3-snort-release, path: releases/snort}
@@ -425,6 +433,10 @@ jobs:
       passed:
       - common-releases-tooling
     - get: cg-s3-awslogs-bionic-release
+      trigger: true
+      passed:
+      - common-releases-tooling
+    - get: cg-s3-awslogs-jammy-release
       trigger: true
       passed:
       - common-releases-tooling
@@ -553,6 +565,10 @@ jobs:
       passed:
       - common-releases-development
     - get: cg-s3-awslogs-bionic-release
+      trigger: true
+      passed:
+      - common-releases-development
+    - get: cg-s3-awslogs-jammy-release
       trigger: true
       passed:
       - common-releases-development
@@ -839,6 +855,12 @@ resources:
   type: s3-iam
   source:
     regexp: awslogs-bionic-(.*).tgz
+    <<: *s3-release-params
+
+- name: cg-s3-awslogs-jammy-release
+  type: s3-iam
+  source:
+    regexp: awslogs-jammy-(.*).tgz
     <<: *s3-release-params
 
 - name: cg-s3-nessus-agent-release

--- a/ci/update-runtime-config.yml
+++ b/ci/update-runtime-config.yml
@@ -13,6 +13,7 @@ inputs:
 - {name: cg-s3-fisma-release, path: releases/fisma}
 - {name: aide-release, path: releases/aide}
 - {name: cg-s3-awslogs-bionic-release, path: releases/awslogs-bionic}
+- {name: cg-s3-awslogs-jammy-release, path: releases/awslogs-jammy}
 - {name: cg-s3-nessus-agent-release, path: releases/nessus-agent}
 - {name: cg-s3-clamav-release, path: releases/clamav}
 - {name: cg-s3-snort-release, path: releases/snort}

--- a/runtime-config/runtime.yml
+++ b/runtime-config/runtime.yml
@@ -4,6 +4,7 @@ releases:
 - {name: clamav, version: ((release_clamav))}
 - {name: snort, version: ((release_snort))}
 - {name: awslogs-bionic, version: ((release_awslogs_bionic))}
+- {name: awslogs-jammy, version: ((release_awslogs_jammy))}
 - {name: nessus-agent, version: ((release_nessus_agent))}
 - {name: node-exporter, version: ((release_node_exporter))}
 - {name: syslog, version: ((release_syslog))}
@@ -46,6 +47,36 @@ addons:
         group: ((/nessus_agent_group))
         server: ((terraform_outputs.nessus_static_ip))
         port: 8834
+  - name: awslogs-jammy
+    release: awslogs-jammy
+    properties:
+      awslogs-jammy:
+        region: us-gov-west-1
+        awslogs_files_config:
+        - name: /var/log/audit/audit.log
+          file: /var/log/audit/audit.log
+          log_group_name: /var/log/audit/audit.log
+          log_stream_name: "{{instance_id}}"
+          initial_position: start_of_file
+          datetime_format: "%Y-%m-%dT%H:%M:%S"
+        - name: /var/log/auth.log
+          file: /var/log/auth.log
+          log_group_name: /var/log/auth.log
+          log_stream_name: "{{instance_id}}"
+          initial_position: start_of_file
+          datetime_format: "%Y-%m-%dT%H:%M:%S"
+        - name: /var/log/dpkg.log
+          file: /var/log/dpkg.log
+          log_group_name: /var/log/dpkg.log
+          log_stream_name: "{{instance_id}}"
+          initial_position: start_of_file
+          datetime_format: "%Y-%m-%dT%H:%M:%S"
+        - name: /var/log/syslog
+          file: /var/log/syslog
+          log_group_name: /var/log/syslog
+          log_stream_name: "{{instance_id}}"
+          initial_position: start_of_file
+          datetime_format: "%Y-%m-%dT%H:%M:%S"
 - include:
     stemcell:
     - os: ubuntu-bionic


### PR DESCRIPTION
Related to https://github.com/cloud-gov/product/issues/2397

## Changes proposed in this pull request:

- Add awslogs-jammy to runtime config for VMs on Jammy stemcells
- Add awslogs-jammy release to be referenced by pipeline for dev/stage

## security considerations

None
