### PR TITLE
add awslogs-jammy release as trigger for prod

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -695,6 +695,10 @@ jobs:
       trigger: true
       passed:
       - common-releases-staging
+    - get: cg-s3-awslogs-jammy-release
+      trigger: true
+      passed:
+      - common-releases-staging
     - get: cg-s3-nessus-agent-release
       trigger: true
       passed:


### PR DESCRIPTION
Related to https://github.com/cloud-gov/product/issues/2397

## Changes proposed in this pull request:

Add awslogs-jammy BOSH release as trigger for prod BOSH deployment. However, the awslogs-jammy BOSH release will only be run on VMs using Ubuntu Jammy stemcells per the runtime config.

## security considerations

None
