### PR TITLE
backup master bosh creds.yml to s3

### DIFF
--- a/bosh-create-env.sh
+++ b/bosh-create-env.sh
@@ -37,4 +37,5 @@ set -e
 # ensure state gets copied to output
 cp bosh-state/*.json updated-bosh-state
 
-exit ${code}
+# ensure we copy out creds.yml so we don't miss out on any new bosh-deployment variables
+cp creds.yml updated-bosh-state/master-bosh-creds.yml

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -81,6 +81,10 @@ jobs:
     put: masterbosh-state
     params:
       file: updated-bosh-state/*.json
+  ensure:
+    put: masterbosh-creds
+    params:    
+      file: updated-bosh-state/*.yml
   on_failure:
     put: slack
     params:
@@ -812,6 +816,14 @@ resources:
     bucket: ((secrets-bucket))
     region_name: ((aws-region))
     versioned_file: master-bosh-state.json
+    server_side_encryption: AES256
+
+- name: masterbosh-creds
+  type: s3-iam
+  source:
+    bucket: ((secrets-bucket))
+    region_name: ((aws-region))
+    versioned_file: master-bosh-creds.yml
     server_side_encryption: AES256
 
 - name: cron-release


### PR DESCRIPTION
## Changes proposed in this pull request:
- As part of master bosh `create-env` there is a `creds.yml` that is not backed up and does/can contain some secrets we could need in the event of a restore.  This adds a task to backup that file to the S3 bucket for BOSH

## security considerations
Having all the secrets is a good thing especially with encryption.  I notable one in this file is nats encryption password
