### PR TITLE
updating pipeline and create-env.yml for bosh-creds

### DIFF
--- a/bosh-create-env.yml
+++ b/bosh-create-env.yml
@@ -16,6 +16,7 @@ inputs:
 - name: terraform-yaml
 - name: bosh-config
 - name: bosh-state
+- name: bosh-creds
 - name: terraform-secrets
 - name: nessus-agent-release
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -51,7 +51,9 @@ jobs:
       trigger: true
       resource: terraform-yaml-tooling
     - get: bosh-state
-      resource: masterbosh-state
+      resource: masterbosh-state    
+    - get: bosh-creds
+      resource: masterbosh-creds
     - get: ca-cert-store
       trigger: true
     - get: nessus-agent-release
@@ -78,13 +80,13 @@ jobs:
       BOSH_CLIENT: admin
       BOSH_CLIENT_SECRET: ((master_bosh_admin_password))
   ensure:
-    put: masterbosh-state
-    params:
-      file: updated-bosh-state/*.json
-  ensure:
-    put: masterbosh-creds
-    params:    
-      file: updated-bosh-state/*.yml
+    do:
+    - put: masterbosh-state
+      params:
+        file: updated-bosh-state/*.json
+    - put: masterbosh-creds
+      params:    
+        file: updated-bosh-state/*.yml
   on_failure:
     put: slack
     params:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add in more resource definitions for bosh-creds resource to track `create-env` `creds.yml` in S3 so we don't loose new secrets

## security considerations
Keeping secrets is a good thing - even better when we need them for recovery