### PR TITLE
adding in logic to reserve ip for internal domain lb

### DIFF
--- a/cloud-config/main.yml
+++ b/cloud-config/main.yml
@@ -36,6 +36,7 @@
       gateway: ((terraform_outputs.services_subnet_gateway_az1))
       reserved:
       - ((terraform_outputs.services_subnet_reserved_az1))
+      - ((terraform_outputs.domains-internal-ip-az1))
       static: ((terraform_outputs.services_static_ips))
       dns: [((terraform_outputs.vpc_cidr_dns))]
       cloud_properties:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add in reserved IP into cloud-config for services network for internal domains LB so BOSH doesn't try to use that IP

## Notes
BOSH is only aware of IPs in use either by what is defined in the reserve range or IPs it uses to deploy VMs. So by having IPs in use in either the static or dynamic range defined to a BOSH network, BOSH can try and use that IP, run into an IP conflict, and not finish a deployment due to the error and cause a blockage until the issue is resolved.

## security considerations
n/a