### PR TITLE
Adding resize for aws disk

### DIFF
--- a/operations/cpi.yml
+++ b/operations/cpi.yml
@@ -13,3 +13,7 @@
 - type: replace
   path: /instance_groups/name=bosh/properties/aws/encrypted?
   value: true
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/director/enable_cpi_resize_disk?
+  value: true


### PR DESCRIPTION
## Changes proposed in this pull request:
- Enable CPI IaaS resize for storage volumes

## Notes
This allows native AWS EBS expansion rather then attach new and `rsync` data

## security considerations
N/A
