### PR TITLE
remove local blobstore job

### DIFF
--- a/operations/s3-blobstore.yml
+++ b/operations/s3-blobstore.yml
@@ -1,4 +1,7 @@
 - type: remove
+  path: /instance_groups/name=bosh/jobs/name=blobstore
+
+- type: remove
   path: /instance_groups/name=bosh/properties/agent/env/bosh/blobstores
 
 - type: replace
@@ -10,3 +13,4 @@
       region: ((terraform_outputs.vpc_region))
       credentials_source: env_or_profile
       server_side_encryption: AES256
+


### PR DESCRIPTION
## Changes proposed in this pull request:
- Since we are specifying s3 blobstore. We don't need dav blobstore at all
-
-

## security considerations
Actually reduces stuff in BOSH VM