### PR TITLE
Updating logsearch volume in staging as a test for prod

### DIFF
--- a/cloud-config/staging.yml
+++ b/cloud-config/staging.yml
@@ -1,3 +1,3 @@
 - type: replace
   path: /disk_types/name=logsearch_es_data/disk_size
-  value: 600_000
+  value: 900_000


### PR DESCRIPTION
## Changes proposed in this pull request:
- Updating logsearch volume to 900 GB as a test for modifying production
-
-

## security considerations
None, we're just updating a volume size