### PR TITLE
Updated logsearch to move from 7 to 12 TB to give more room in Prod

### DIFF
--- a/cloud-config/main.yml
+++ b/cloud-config/main.yml
@@ -58,7 +58,7 @@
   path: /disk_types/-
   value:
     name: logsearch_es_data
-    disk_size: 7_000_000
+    disk_size: 12_000_000
 - type: replace
   path: /disk_types/-
   value:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Updated the disk size from 7 to 12 TB to give logsearch more room
-
-

## security considerations
None, just changing disk size