### PR TITLE
Removing extra jobs which talk to a local db

### DIFF
--- a/operations/external-db-protobosh.yml
+++ b/operations/external-db-protobosh.yml
@@ -435,3 +435,11 @@
 
 - type: remove
   path: /variables/name=postgres_password
+
+
+
+- type: remove
+  path: /instance_groups/name=bosh/jobs/name=bbr-uaadb?
+
+- type: remove
+  path: /instance_groups/name=bosh/jobs/name=bbr-credhubdb?

--- a/operations/s3-blobstore-protobosh.yml
+++ b/operations/s3-blobstore-protobosh.yml
@@ -30,3 +30,15 @@
       credentials_source: env_or_profile
       server_side_encryption: AES256
 
+- type: remove
+  path: /resource_pools/name=vms/env/bosh/blobstores
+
+- type: replace
+  path: /resource_pools/name=vms/env/bosh/blobstores?/-
+  value:
+    provider: s3
+    options:
+      bucket_name: ((terraform_outputs.protobosh_blobstore_bucket))
+      region: ((terraform_outputs.vpc_region))
+      credentials_source: env_or_profile
+      server_side_encryption: AES256


### PR DESCRIPTION
## Changes proposed in this pull request:
- Removing extra jobs which talk to a local db
-
-

## security considerations
None, forces the RDS db to be used instead of a local postgres instance
