### PR TITLE
updated ca cert to use the ca

### DIFF
--- a/operations/ca.yml
+++ b/operations/ca.yml
@@ -42,6 +42,6 @@
 
 - type: replace
   path: /instance_groups/name=bosh/properties/director/trusted_certs?
-  value: ((default_ca))
+  value: ((default_ca.ca))
 
     


### PR DESCRIPTION
## Changes proposed in this pull request:
- Updated the ca.yml to use default_ca.ca
-
-

## security considerations

None, we are using a cert which ultimately is better security