### PR TITLE
Adding a separate cpi for protobosh to use distinct instance profile

### DIFF
--- a/operations/cpi-protobosh.yml
+++ b/operations/cpi-protobosh.yml
@@ -1,0 +1,19 @@
+- type: replace
+  path: /instance_groups/name=bosh/properties/aws/default_iam_instance_profile?
+  value: ((terraform_outputs.protobosh_profile))
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/aws/default_security_groups
+  value: [((terraform_outputs.bosh_security_group))]
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/aws/region
+  value: ((terraform_outputs.vpc_region))
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/aws/encrypted?
+  value: true
+
+- type: replace
+  path: /instance_groups/name=bosh/properties/director/enable_cpi_resize_disk?
+  value: true


### PR DESCRIPTION
## Changes proposed in this pull request:
- Adding a separate cpi for protobosh to use distinct instance profile
-
-

## security considerations
Allows us to distinguish between what tooling is using as a default profile and what protobosh is using
