### PR TITLE
fix for cron.yml in tooling for missing gateway

### DIFF
--- a/variables/tooling.yml
+++ b/variables/tooling.yml
@@ -3,5 +3,5 @@ environment: tooling
 deployment_name: toolingbosh
 network: bosh
 instance_profile: bosh-profile
-gateway_host: ""
+gateway_host: prometheus-tooling.service.cf.internal
 gateway_deployment: prometheus-production


### PR DESCRIPTION
## Changes proposed in this pull request:
- The current configuration doesn't allow the results of the cron job to be pushed to prometheus
-
-

## security considerations
This should alert us going forward of instances in tooling provisioned outside of the bosh director
