### PR TITLE
Changes needed for tooling bosh

### DIFF
--- a/cloud-config/protobosh.yml
+++ b/cloud-config/protobosh.yml
@@ -42,7 +42,7 @@
 - type: replace
   path: /vm_extensions/-
   value:
-    name: bosh-profile
+    name: ((terraform_outputs.bosh_profile))
     cloud_properties:
       iam_instance_profile: ((terraform_outputs.bosh_profile))
 
@@ -62,3 +62,17 @@
     name: z3
     cloud_properties:
       availability_zone: ((terraform_outputs.az3))
+
+
+- type: remove
+  path: /vm_types/name=c5.xlarge.compilation
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: c5.xlarge.compilation
+    cloud_properties:
+      ephemeral_disk:
+        size: 30000
+      iam_instance_profile: ((terraform_outputs.protobosh_compilation_profile))
+      instance_type: c5.xlarge

--- a/operations/external-db-bosh-rds.yml
+++ b/operations/external-db-bosh-rds.yml
@@ -436,3 +436,9 @@
 
 - type: remove
   path: /variables/name=postgres_password
+
+- type: remove
+  path: /instance_groups/name=bosh/jobs/name=bbr-uaadb?
+
+- type: remove
+  path: /instance_groups/name=bosh/jobs/name=bbr-credhubdb?

--- a/operations/use-c5-large.yml
+++ b/operations/use-c5-large.yml
@@ -1,0 +1,3 @@
+- path: /resource_pools/name=vms/cloud_properties/instance_type?
+  type: replace
+  value: c5.large

--- a/variables/westa-hub-tooling.yml
+++ b/variables/westa-hub-tooling.yml
@@ -2,6 +2,6 @@ director_name: toolingbosh
 environment: tooling
 deployment_name: toolingbosh
 network: bosh
-instance_profile: westa-hub-default
+instance_profile: westa-hub-bosh
 gateway_host: prometheus-tooling.service.cf.internal
 gateway_deployment: prometheus-production


### PR DESCRIPTION
## Changes proposed in this pull request:
- Remove unused bbr jobs that would consume resources but not be used since we leverage rds snapshots
- Bumped default instance type for protobosh
- Use the more restricted instance profile created specifically for the toolingbosh
- Change to cloud config needed to deploy tooling bosh

## security considerations
Removes potential attack surface of unused bbr jobs and tightens instance profile in use
