### PR TITLE
removing opensearch as it has a pipeline to make a new release

### DIFF
--- a/releases/releases.yml
+++ b/releases/releases.yml
@@ -3,9 +3,6 @@ release_blobstore_bucket: cloud-gov-release-blobstore
 aws_region: us-gov-west-1
 
 releases:
-- name: opensearch
-  uri: https://github.com/cloud-gov/opensearch-boshrelease
-  branch: main
 - name: fisma
   uri: https://github.com/cloud-gov/cg-harden-boshrelease
   branch: main


### PR DESCRIPTION
## Changes proposed in this pull request:
- remove opensearch because it has its own pipeline to make releases
-
-

## security considerations
none
