### PR TITLE
Add vm_extension for uaa load balancer

### DIFF
--- a/cloud-config/cf.yml
+++ b/cloud-config/cf.yml
@@ -114,6 +114,13 @@
 - type: replace
   path: /vm_extensions/-
   value:
+    name: cf-router-main-network-properties
+    cloud_properties:
+      lb_target_groups: 
+        - ((terraform_outputs.cf_uaa_target_group))
+- type: replace
+  path: /vm_extensions/-
+  value:
     name: diego-ssh-proxy-network-properties
     cloud_properties:
       elbs: [((terraform_outputs.diego_elb_name))]

--- a/cloud-config/protobosh.yml
+++ b/cloud-config/protobosh.yml
@@ -42,7 +42,7 @@
 - type: replace
   path: /vm_extensions/-
   value:
-    name: bosh-profile
+    name: ((terraform_outputs.bosh_profile))
     cloud_properties:
       iam_instance_profile: ((terraform_outputs.bosh_profile))
 
@@ -62,3 +62,17 @@
     name: z3
     cloud_properties:
       availability_zone: ((terraform_outputs.az3))
+
+
+- type: remove
+  path: /vm_types/name=c5.xlarge.compilation
+
+- type: replace
+  path: /vm_types/-
+  value:
+    name: c5.xlarge.compilation
+    cloud_properties:
+      ephemeral_disk:
+        size: 30000
+      iam_instance_profile: ((terraform_outputs.protobosh_compilation_profile))
+      instance_type: c5.xlarge


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add another vm_extension for the uaa load balancer
- Background: The uaa load balancer is being removed from the cf-router-network-properties vm_extension into its own so the traffic can be split via cg-provision's outputs.tf in the main stack
-

## security considerations
None
