### PR TITLE
update disk types to gp3

### DIFF
--- a/cloud-config/main.yml
+++ b/cloud-config/main.yml
@@ -54,26 +54,36 @@
   value:
     name: logsearch_es_master
     disk_size: 102400
+    cloud_properties:
+      type: gp3
 - type: replace
   path: /disk_types/-
   value:
     name: logsearch_es_data
     disk_size: 12_000_000
+    cloud_properties:
+      type: gp3
 - type: replace
   path: /disk_types/-
   value:
     name: logsearch_es_platform_data
     disk_size: 3_500_000
+    cloud_properties:
+      type: gp3
 - type: replace
   path: /disk_types/-
   value:
     name: logsearch_ingestor
     disk_size: 64_000
+    cloud_properties:
+      type: gp3
 - type: replace
   path: /disk_types/-
   value:
     name: logsearch_redis
     disk_size: 4096
+    cloud_properties:
+      type: gp3
 - type: replace
   path: /disk_types/-
   value:

--- a/cloud-config/tooling.yml
+++ b/cloud-config/tooling.yml
@@ -407,11 +407,15 @@
   value: &prometheus-small-disk
     name: staging-prometheus-small
     disk_size: 8192
+    cloud_properties:
+      type: gp3
 - type: replace
   path: /disk_types/-
   value: &prometheus-large-disk
     name: staging-prometheus-large
     disk_size: 200_000
+    cloud_properties:
+      type: gp3
 - type: replace
   path: /disk_types/-
   value:

--- a/cloud-config/tooling.yml
+++ b/cloud-config/tooling.yml
@@ -390,6 +390,8 @@
   value:
     name: bosh
     disk_size: 92_000
+    cloud_properties:
+      type: gp3
 - type: replace
   path: /disk_types/-
   value:

--- a/cloud-config/tooling.yml
+++ b/cloud-config/tooling.yml
@@ -400,6 +400,8 @@
   value:
     name: nessus-manager
     disk_size: 200_000
+    cloud_properties:
+      type: gp3
 - type: replace
   path: /disk_types/-
   value: &prometheus-small-disk


### PR DESCRIPTION
Related to https://github.com/cloud-gov/product/issues/2376

## Changes proposed in this pull request:

- move types to use gp3 instead of gp2. gp3 is now the default for disk types on AWS, but some of these disk types precede that change, so they have to be upgraded to gp3

## security considerations

None, just moving from gp2 to gp3 volumes to optimize cost and performance
