### PR TITLE
Update master bosh cc for gp3 for tooling

### DIFF
--- a/cloud-config/master.yml
+++ b/cloud-config/master.yml
@@ -33,6 +33,8 @@
   value:
     name: bosh
     disk_size: 300000
+    cloud_properties:
+      type: gp3
 
 - type: replace
   path: /compilation/network?


### PR DESCRIPTION
Related to https://github.com/cloud-gov/product/issues/2376

## Changes proposed in this pull request:
- Update the cloud-config template uploaded to the master bosh for deploying the tooling bosh to use gp3 disk
-
-

## security considerations
None
