### PR TITLE
updating cron boshrelease to use forked internal repo

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -843,7 +843,7 @@ resources:
 - name: cron-release
   type: bosh-io-release
   source:
-    repository: cloudfoundry-community/cron-boshrelease
+    repository: cloud-gov/cron-boshrelease
 
 - name: syslog-release
   type: bosh-io-release

--- a/releases/releases.yml
+++ b/releases/releases.yml
@@ -32,7 +32,7 @@ releases:
   branch: main
 - name: cron
   uri: https://github.com/cloud-gov/cron-boshrelease
-  branch: master
+  branch: main
 - name: oauth2-proxy
   uri: https://github.com/cloud-gov/oauth2-proxy-boshrelease
   branch: main

--- a/releases/releases.yml
+++ b/releases/releases.yml
@@ -31,7 +31,7 @@ releases:
   uri: https://github.com/cloud-gov/uaa-customized-boshrelease
   branch: main
 - name: cron
-  uri: https://github.com/cloudfoundry-community/cron-boshrelease
+  uri: https://github.com/cloud-gov/cron-boshrelease
   branch: master
 - name: oauth2-proxy
   uri: https://github.com/cloud-gov/oauth2-proxy-boshrelease


### PR DESCRIPTION
## Changes proposed in this pull request:
- Replaced cloudfroundry-community with cloud-gov for the cron-boshrelease
- 
-

## security considerations
None