### PR TITLE
Adding new instance type for concourse web

### DIFF
--- a/cloud-config/base.yml
+++ b/cloud-config/base.yml
@@ -143,6 +143,11 @@ vm_types:
     instance_type: m5.large
   name: m5.large
 - cloud_properties:
+    instance_type: m5.large
+    ephemeral_disk:
+      size: 45000
+  name: m5.large.concourse.web
+- cloud_properties:
     instance_type: m5.metal
   name: m5.metal
 - cloud_properties:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add m5.large.concourse.web instance type to the cloud config so it can be used on Tooling for concourse
- Web nodes have higher than desired swap usage
- Part II is to change cg-deploy-concourse

## security considerations
None
