### PR TITLE
Adding environment tags to BOSH deployments

### DIFF
--- a/ci/update-runtime-config.sh
+++ b/ci/update-runtime-config.sh
@@ -18,7 +18,9 @@ popd
 bosh -n update-runtime-config \
   bosh-config/runtime-config/runtime.yml \
   --vars-env runtime \
+  --var=bosh_environment=${BOSH_ENV_NAME} \
   --vars-file terraform-yaml/state.yml
+
 
 bosh -n update-runtime-config --name dns \
   bosh-deployment/runtime-configs/dns.yml \

--- a/operations/cpi.yml
+++ b/operations/cpi.yml
@@ -19,5 +19,5 @@
   value: true
 
 - type: replace
-  path: /tags?/cg_environment?
+  path: /tags?/environment?
   value: ((environment))

--- a/operations/cpi.yml
+++ b/operations/cpi.yml
@@ -17,3 +17,7 @@
 - type: replace
   path: /instance_groups/name=bosh/properties/director/enable_cpi_resize_disk?
   value: true
+
+- type: replace
+  path: /tags?/cg_environment?
+  value: ((environment))

--- a/runtime-config/runtime.yml
+++ b/runtime-config/runtime.yml
@@ -150,7 +150,8 @@ addons:
       syslog:
         address: ((terraform_outputs.platform_syslog_elb_dns_name))
         port: 5514
-
+tags:
+  cg_environment: ((bosh_environment))
 variables:
 - name: nessus_agent_key
   type: password

--- a/runtime-config/runtime.yml
+++ b/runtime-config/runtime.yml
@@ -151,7 +151,7 @@ addons:
         address: ((terraform_outputs.platform_syslog_elb_dns_name))
         port: 5514
 tags:
-  cg_environment: ((bosh_environment))
+  environment: ((bosh_environment))
 variables:
 - name: nessus_agent_key
   type: password

--- a/variables/master.yml
+++ b/variables/master.yml
@@ -1,2 +1,3 @@
 director_name: master-bosh
 private_key: ../ca.key
+environment: master


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add a new tag called `cg_environment` with the corresponding environment on each BOSH director and BOSH deployment
- This will allow us to add that tag to AWS Cost explorer so we can better group EC2 resources where deployments don't have environment names aka logsearch
- This also adds the tags run runtime configs for tooling/dev/stage/prod as well

## Fun Fact
Local manifest tags take preference over runtime tags

## security considerations
By tagging EC2 resources deployed by BOSH helps us better audit our environments 
