### PR TITLE
update release pipeline to use hardened images

### DIFF
--- a/releases/pipeline.yml.erb
+++ b/releases/pipeline.yml.erb
@@ -18,14 +18,14 @@ resource_types:
     aws_region: us-gov-west-1
     tag: latest
 
-    - name: git
-    type: registry-image
-    source:
-      aws_access_key_id: ((ecr_aws_key))
-      aws_secret_access_key: ((ecr_aws_secret))
-      repository: git-resource
-      aws_region: us-gov-west-1
-      tag: latest
+- name: git
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: git-resource
+    aws_region: us-gov-west-1
+    tag: latest
 
 resources:
 - name: pipeline-tasks

--- a/releases/pipeline.yml.erb
+++ b/releases/pipeline.yml.erb
@@ -1,9 +1,31 @@
 ---
 resource_types:
-- name: s3-iam
-  type: docker-image
+- name: registry-image
+  type: registry-image
   source:
-    repository: 18fgsa/s3-resource
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: registry-image-resource
+    aws_region: us-gov-west-1
+    tag: latest
+
+- name: s3-iam
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: s3-resource
+    aws_region: us-gov-west-1
+    tag: latest
+
+    - name: git
+    type: registry-image
+    source:
+      aws_access_key_id: ((ecr_aws_key))
+      aws_secret_access_key: ((ecr_aws_secret))
+      repository: git-resource
+      aws_region: us-gov-west-1
+      tag: latest
 
 resources:
 - name: pipeline-tasks


### PR DESCRIPTION
## Changes proposed in this pull request:
- Updates the bosh release pipeline to use hardened image

## security considerations
Pipeline should be using hardened images
