### PR TITLE
Removed references to bionic releases

### DIFF
--- a/ci/update-runtime-config.yml
+++ b/ci/update-runtime-config.yml
@@ -11,21 +11,18 @@ image_resource:
     tag: ((harden-concourse-task-tag))
 
 inputs:
-- {name: bosh-config}
-- {name: bosh-deployment}
-- {name: certificate}
-- {name: terraform-yaml}
-- {name: cg-s3-fisma-release, path: releases/fisma}
-- {name: cg-s3-fisma-jammy-release, path: releases/fisma-jammy}
-- {name: aide-release, path: releases/aide}
-- {name: cg-s3-awslogs-bionic-release, path: releases/awslogs-bionic}
-- {name: cg-s3-awslogs-jammy-release, path: releases/awslogs-jammy}
-- {name: cg-s3-nessus-agent-release, path: releases/nessus-agent}
-- {name: cg-s3-clamav-release, path: releases/clamav}
-- {name: cg-s3-snort-release, path: releases/snort}
-- {name: cg-s3-jammy-snort-release, path: releases/jammy-snort}
-- {name: node-exporter-release, path: releases/node-exporter}
-- {name: syslog-release, path: releases/syslog}
+  - { name: bosh-config }
+  - { name: bosh-deployment }
+  - { name: certificate }
+  - { name: terraform-yaml }
+  - { name: cg-s3-fisma-jammy-release, path: releases/fisma-jammy }
+  - { name: aide-release, path: releases/aide }
+  - { name: cg-s3-awslogs-jammy-release, path: releases/awslogs-jammy }
+  - { name: cg-s3-nessus-agent-release, path: releases/nessus-agent }
+  - { name: cg-s3-clamav-release, path: releases/clamav }
+  - { name: cg-s3-jammy-snort-release, path: releases/jammy-snort }
+  - { name: node-exporter-release, path: releases/node-exporter }
+  - { name: syslog-release, path: releases/syslog }
 
 run:
   path: bosh-config/ci/update-runtime-config.sh


### PR DESCRIPTION
## Changes proposed in this pull request:
- Removed references to bionic in the runtime config
- Looked at the deps in all environments
- PR https://github.com/cloud-gov/deploy-logs-opensearch/pull/54 created to remove bionic snort release from opensearch to support this PR


## security considerations
None, removing references
