### PR TITLE
Moving to use pre-complied releases from bosh-deployment to reduce masterbosh deployment time

### DIFF
--- a/bosh-create-env.sh
+++ b/bosh-create-env.sh
@@ -16,9 +16,6 @@ bosh create-env \
   --ops-file bosh-deployment/aws/cli-iam-instance-profile.yml \
   --ops-file bosh-deployment/uaa.yml \
   --ops-file bosh-deployment/credhub.yml \
-  --ops-file bosh-deployment/misc/source-releases/bosh.yml \
-  --ops-file bosh-deployment/misc/source-releases/credhub.yml \
-  --ops-file bosh-deployment/misc/source-releases/uaa.yml \
   --ops-file bosh-deployment/jumpbox-user.yml \
   --ops-file bosh-config/operations/cpi.yml \
   --ops-file bosh-config/operations/encryption.yml \


### PR DESCRIPTION
## Changes proposed in this pull request:
-  Moving the masterbosh create-env script to use the precomplied releases coming from bosh deployment to reduce deployment time


## security considerations
None
