### PR TITLE
bumping logsearch dev data disk

### DIFF
--- a/cloud-config/development.yml
+++ b/cloud-config/development.yml
@@ -1,6 +1,6 @@
 - type: replace
   path: /disk_types/name=logsearch_es_data/disk_size
-  value: 300_000
+  value: 400_000
 - type: replace
   path: /disk_types/name=logsearch_es_platform_data/disk_size
   value: 200_000


### PR DESCRIPTION
## Changes proposed in this pull request:
- logsearch dev nodes hit 90% disk space in use - bumping disk

## security considerations
none
