### PR TITLE
lighten the load on concourse

### DIFF
--- a/releases/pipeline.yml.erb
+++ b/releases/pipeline.yml.erb
@@ -24,6 +24,7 @@ resources:
 - name: <%= release['name'] %>-release-tarball
   type: s3-iam
   source:
+    check_every: never
     bucket: <%= bosh_release_bucket %>
     regexp: <%= release['name'] %>-(.*).tgz
     region_name: <%= aws_region %>
@@ -32,6 +33,7 @@ resources:
 - name: <%= release['name'] %>-final-builds-dir-tarball
   type: s3-iam
   source:
+    check_every: never
     bucket: <%= bosh_release_bucket %>
     versioned_file: final-builds-dir-<%= release['name'] %>.tgz
     region_name: <%= aws_region %>
@@ -40,6 +42,7 @@ resources:
 - name: <%= release['name'] %>-releases-dir-tarball
   type: s3-iam
   source:
+    check_every: never
     bucket: <%= bosh_release_bucket %>
     versioned_file: releases-dir-<%= release['name'] %>.tgz
     region_name: <%= aws_region %>
@@ -54,7 +57,9 @@ jobs:
     - get: release-git-repo
       resource: <%= release['name'] %>-release-git-repo
       trigger: true
+      params: {depth: 1}
     - get: pipeline-tasks
+      params: {depth: 1}
     - get: final-builds-dir-tarball
       resource: <%= release['name'] %>-final-builds-dir-tarball
     - get: releases-dir-tarball


### PR DESCRIPTION
This is an attempt at being kinder to connie.

## Changes proposed in this pull request:
- don't check release resources, since we are the only ones creating them. I am unsure if this will work. My thinking is that concourse should almost always know the resource version on its own, since this pipeline should be all that's putting it. The only other time these should change is when operators are manually putting versions, in which case we can also manually press the button
- do shallow checkouts, since we don't need history

## security considerations
None