### PR TITLE
making large instance type for nessus mgr

### DIFF
--- a/cloud-config/tooling.yml
+++ b/cloud-config/tooling.yml
@@ -321,6 +321,14 @@
 - type: replace
   path: /vm_types/-
   value:
+    name: m6i.large.nessus.manager
+    cloud_properties:
+      instance_type: m6i.large
+      ephemeral_disk:
+        size: 30_000
+- type: replace
+  path: /vm_types/-
+  value:
     <<: *concourse-iaas-worker-vm
     name: production-concourse-iaas-worker
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- Nessus manager is using a burstable T class and running into CPU and memory constraints to moving to a larger/stable instance class 

## security considerations
n/a
