### PR TITLE
Remove references to pages concourse

### DIFF
--- a/cloud-config/tooling.yml
+++ b/cloud-config/tooling.yml
@@ -77,24 +77,7 @@
             - ((terraform_outputs.bosh_security_group))
             - ((terraform_outputs.production_concourse_security_group))
             - ((terraform_outputs.production_credhub_security_group))
-- type: replace
-  path: /networks/-
-  value:
-    name: production-concourse-pages
-    type: manual
-    subnets:
-      - range: ((terraform_outputs.production_concourse_pages_subnet_cidr))
-        gateway: ((terraform_outputs.production_concourse_pages_subnet_gateway))
-        reserved:
-          - ((terraform_outputs.production_concourse_pages_subnet_reserved))
-        az: z2
-        dns: [((terraform_outputs.vpc_cidr_dns))]
-        cloud_properties:
-          subnet: ((terraform_outputs.production_concourse_pages_subnet))
-          security_groups:
-            - ((terraform_outputs.bosh_security_group))
-            - ((terraform_outputs.production_concourse_pages_security_group))
-            - ((terraform_outputs.production_credhub_security_group))
+
 - type: replace
   path: /networks/-
   value:
@@ -407,13 +390,7 @@
     cloud_properties:
       lb_target_groups:
         - ((terraform_outputs.production_concourse_lb_target_group))
-- type: replace
-  path: /vm_extensions/-
-  value:
-    name: production-concourse-pages-lb
-    cloud_properties:
-      lb_target_groups:
-        - ((terraform_outputs.production_concourse_pages_lb_target_group))
+
 - type: replace
   path: /vm_extensions/-
   value:


### PR DESCRIPTION
## Changes proposed in this pull request:
- Deployment was torn down so no longer need cloud config network and vm extension blocks for it
- Closes https://github.com/cloud-gov/private/issues/1369
-

## security considerations
None.  Removes references to deprecated deployment
